### PR TITLE
Bypassing builds on ios and android.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5929,7 +5929,7 @@ dependencies = [
 [[package]]
 name = "zktrie"
 version = "0.2.0"
-source = "git+https://github.com/scroll-tech/zktrie.git?branch=v0.7#a130ea543d291d4b71724f91cb8a49745c593a0c"
+source = "git+https://github.com/polybase/zktrie/?branch=bypass-builds-on-android-and-ios#5c2ff7455d8e1472a2ea43900b3fa52ec5c8137d"
 dependencies = [
  "gobuild 0.1.0-alpha.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/geth-utils/build.rs
+++ b/geth-utils/build.rs
@@ -4,6 +4,24 @@ use std::{
 };
 
 fn main() {
+    if let Some(target) = env::var("TARGET").ok() {
+        if target.contains("android") || target.contains("ios") {
+            println!("cargo:warning=Building for Android or iOS");
+            return;
+        }
+    } else {
+        println!("cargo:warning=Building for non-mobile platforms");
+    }
+
+    if let Some(target) = env::var("TARGET").ok() {
+        if target.contains("android") {
+            println!("cargo:warning=Building for Android");
+            return;
+        }
+    } else {
+        println!("cargo:warning=Building for non-Android");
+    }
+
     let lib_name = "go-geth-utils";
     let out_dir = env::var("OUT_DIR").unwrap();
 

--- a/geth-utils/build.rs
+++ b/geth-utils/build.rs
@@ -4,22 +4,13 @@ use std::{
 };
 
 fn main() {
-    if let Some(target) = env::var("TARGET").ok() {
+    if let Ok(target) = env::var("TARGET") {
         if target.contains("android") || target.contains("ios") {
             println!("cargo:warning=Building for Android or iOS");
             return;
         }
     } else {
         println!("cargo:warning=Building for non-mobile platforms");
-    }
-
-    if let Some(target) = env::var("TARGET").ok() {
-        if target.contains("android") {
-            println!("cargo:warning=Building for Android");
-            return;
-        }
-    } else {
-        println!("cargo:warning=Building for non-Android");
     }
 
     let lib_name = "go-geth-utils";

--- a/zktrie/Cargo.toml
+++ b/zktrie/Cargo.toml
@@ -9,7 +9,7 @@ license.workspace = true
 [dependencies]
 halo2_proofs.workspace = true
 mpt-circuits = { package = "halo2-mpt-circuits", git = "https://github.com/scroll-tech/mpt-circuit.git", tag = "v0.7.0" }
-zktrie = { git = "https://github.com/scroll-tech/zktrie.git", branch = "v0.7"}
+zktrie = { git = "https://github.com/polybase/zktrie/", branch = "bypass-builds-on-android-and-ios"}
 hash-circuit.workspace = true
 eth-types = { path = "../eth-types" }
 lazy_static.workspace = true


### PR DESCRIPTION
### Description

 * Changes - bypassing builds for android and ios (for `geth-utils` and `zktrie` dependencies).

### Issue Link

https://linear.app/polybase/issue/ENG-1305/add-utxo-proof-to-react-native

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Manually, locally.
